### PR TITLE
Add all model search features (distinguishing between source models and target models)

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -40,7 +40,7 @@ const docTemplate = `{
                     "200": {
                         "description": "(sample) This is a list of models",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetCloudModelsResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetCloudModelsResp"
                         }
                     },
                     "404": {
@@ -70,7 +70,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateCloudModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateCloudModelReq"
                         }
                     }
                 ],
@@ -78,7 +78,7 @@ const docTemplate = `{
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateCloudModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateCloudModelResp"
                         }
                     },
                     "400": {
@@ -116,7 +116,7 @@ const docTemplate = `{
                     "200": {
                         "description": "(Sample) a model",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetCloudModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetCloudModelResp"
                         }
                     },
                     "404": {
@@ -153,7 +153,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateCloudModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateCloudModelReq"
                         }
                     }
                 ],
@@ -161,7 +161,7 @@ const docTemplate = `{
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateCloudModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateCloudModelResp"
                         }
                     },
                     "400": {
@@ -232,19 +232,57 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResHTTPVersion"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResHTTPVersion"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResHTTPVersion"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResHTTPVersion"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResHTTPVersion"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResHTTPVersion"
+                        }
+                    }
+                }
+            }
+        },
+        "/model/{isTargetModel}": {
+            "get": {
+                "description": "Get a list of all user models.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration Models"
+                ],
+                "summary": "Get a list of all user models",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Is TargetModel ?",
+                        "name": "isTargetModel",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "(sample) This is a list of models",
+                        "schema": {
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetModelsResp"
+                        }
+                    },
+                    "404": {
+                        "description": "model not found",
+                        "schema": {
+                            "type": "object"
                         }
                     }
                 }
@@ -267,7 +305,7 @@ const docTemplate = `{
                     "200": {
                         "description": "(sample) This is a list of models",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetOnPremModelsResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetOnPremModelsResp"
                         }
                     },
                     "404": {
@@ -297,7 +335,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateOnPremModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateOnPremModelReq"
                         }
                     }
                 ],
@@ -305,7 +343,7 @@ const docTemplate = `{
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateOnPremModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateOnPremModelResp"
                         }
                     },
                     "400": {
@@ -343,7 +381,7 @@ const docTemplate = `{
                     "200": {
                         "description": "(Sample) a model",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetOnPremModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetOnPremModelResp"
                         }
                     },
                     "404": {
@@ -380,7 +418,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateOnPremModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateOnPremModelReq"
                         }
                     }
                 ],
@@ -388,7 +426,7 @@ const docTemplate = `{
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateOnPremModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateOnPremModelResp"
                         }
                     },
                     "400": {
@@ -459,13 +497,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResReadyz"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResReadyz"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResReadyz"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResReadyz"
                         }
                     }
                 }
@@ -473,560 +511,6 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "handler.CloudModelRespInfo": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateCloudModelReq": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateCloudModelResp": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateOnPremModelReq": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateOnPremModelResp": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.GetCloudModelResp": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.GetCloudModelsResp": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handler.CloudModelRespInfo"
-                    }
-                }
-            }
-        },
-        "handler.GetOnPremModelResp": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.GetOnPremModelsResp": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handler.OnPremModelRespInfo"
-                    }
-                }
-            }
-        },
-        "handler.OnPremModelRespInfo": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.ResHTTPVersion": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.ResReadyz": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateCloudModelReq": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateCloudModelResp": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateOnPremModelReq": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateOnPremModelResp": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
         "model.TbMciDynamicReq": {
             "type": "object",
             "required": [
@@ -1417,6 +901,631 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/onprem.RouteProperty"
                     }
+                }
+            }
+        },
+        "pkg_api_rest_handler.CloudModelRespInfo": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateCloudModelReq": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateCloudModelResp": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateOnPremModelReq": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateOnPremModelResp": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetCloudModelResp": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetCloudModelsResp": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pkg_api_rest_handler.CloudModelRespInfo"
+                    }
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetModelsResp": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pkg_api_rest_handler.ModelRespInfo"
+                    }
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetOnPremModelResp": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetOnPremModelsResp": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pkg_api_rest_handler.OnPremModelRespInfo"
+                    }
+                }
+            }
+        },
+        "pkg_api_rest_handler.ModelRespInfo": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel",
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.OnPremModelRespInfo": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.ResHTTPVersion": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.ResReadyz": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateCloudModelReq": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateCloudModelResp": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateOnPremModelReq": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateOnPremModelResp": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
                 }
             }
         }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -33,7 +33,7 @@
                     "200": {
                         "description": "(sample) This is a list of models",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetCloudModelsResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetCloudModelsResp"
                         }
                     },
                     "404": {
@@ -63,7 +63,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateCloudModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateCloudModelReq"
                         }
                     }
                 ],
@@ -71,7 +71,7 @@
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateCloudModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateCloudModelResp"
                         }
                     },
                     "400": {
@@ -109,7 +109,7 @@
                     "200": {
                         "description": "(Sample) a model",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetCloudModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetCloudModelResp"
                         }
                     },
                     "404": {
@@ -146,7 +146,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateCloudModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateCloudModelReq"
                         }
                     }
                 ],
@@ -154,7 +154,7 @@
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateCloudModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateCloudModelResp"
                         }
                     },
                     "400": {
@@ -225,19 +225,57 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResHTTPVersion"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResHTTPVersion"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResHTTPVersion"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResHTTPVersion"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResHTTPVersion"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResHTTPVersion"
+                        }
+                    }
+                }
+            }
+        },
+        "/model/{isTargetModel}": {
+            "get": {
+                "description": "Get a list of all user models.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration Models"
+                ],
+                "summary": "Get a list of all user models",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Is TargetModel ?",
+                        "name": "isTargetModel",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "(sample) This is a list of models",
+                        "schema": {
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetModelsResp"
+                        }
+                    },
+                    "404": {
+                        "description": "model not found",
+                        "schema": {
+                            "type": "object"
                         }
                     }
                 }
@@ -260,7 +298,7 @@
                     "200": {
                         "description": "(sample) This is a list of models",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetOnPremModelsResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetOnPremModelsResp"
                         }
                     },
                     "404": {
@@ -290,7 +328,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateOnPremModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateOnPremModelReq"
                         }
                     }
                 ],
@@ -298,7 +336,7 @@
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.CreateOnPremModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.CreateOnPremModelResp"
                         }
                     },
                     "400": {
@@ -336,7 +374,7 @@
                     "200": {
                         "description": "(Sample) a model",
                         "schema": {
-                            "$ref": "#/definitions/handler.GetOnPremModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.GetOnPremModelResp"
                         }
                     },
                     "404": {
@@ -373,7 +411,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateOnPremModelReq"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateOnPremModelReq"
                         }
                     }
                 ],
@@ -381,7 +419,7 @@
                     "201": {
                         "description": "(Sample) This is a sample description for success response in Swagger UI",
                         "schema": {
-                            "$ref": "#/definitions/handler.UpdateOnPremModelResp"
+                            "$ref": "#/definitions/pkg_api_rest_handler.UpdateOnPremModelResp"
                         }
                     },
                     "400": {
@@ -452,13 +490,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResReadyz"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResReadyz"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/handler.ResReadyz"
+                            "$ref": "#/definitions/pkg_api_rest_handler.ResReadyz"
                         }
                     }
                 }
@@ -466,560 +504,6 @@
         }
     },
     "definitions": {
-        "handler.CloudModelRespInfo": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateCloudModelReq": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateCloudModelResp": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateOnPremModelReq": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.CreateOnPremModelResp": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.GetCloudModelResp": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.GetCloudModelsResp": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handler.CloudModelRespInfo"
-                    }
-                }
-            }
-        },
-        "handler.GetOnPremModelResp": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.GetOnPremModelsResp": {
-            "type": "object",
-            "properties": {
-                "models": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/handler.OnPremModelRespInfo"
-                    }
-                }
-            }
-        },
-        "handler.OnPremModelRespInfo": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.ResHTTPVersion": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.ResReadyz": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateCloudModelReq": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateCloudModelResp": {
-            "type": "object",
-            "required": [
-                "cloudinfra"
-            ],
-            "properties": {
-                "cloudinfra": {
-                    "$ref": "#/definitions/model.TbMciDynamicReq"
-                },
-                "cloudmodelversion": {
-                    "type": "string"
-                },
-                "createtime": {
-                    "type": "string"
-                },
-                "csp": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                },
-                "zone": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateOnPremModelReq": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
-        "handler.UpdateOnPremModelResp": {
-            "type": "object",
-            "required": [
-                "onpreminfra"
-            ],
-            "properties": {
-                "createtime": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iscloudmodel": {
-                    "type": "boolean"
-                },
-                "isinitmodel": {
-                    "type": "boolean"
-                },
-                "istargetmodel": {
-                    "type": "boolean"
-                },
-                "onpreminfra": {
-                    "$ref": "#/definitions/onprem.OnPremInfra"
-                },
-                "onpremmodelversion": {
-                    "type": "string"
-                },
-                "updatetime": {
-                    "type": "string"
-                },
-                "userid": {
-                    "type": "string"
-                },
-                "usermodelname": {
-                    "type": "string"
-                },
-                "usermodelversion": {
-                    "type": "string"
-                }
-            }
-        },
         "model.TbMciDynamicReq": {
             "type": "object",
             "required": [
@@ -1410,6 +894,631 @@
                     "items": {
                         "$ref": "#/definitions/onprem.RouteProperty"
                     }
+                }
+            }
+        },
+        "pkg_api_rest_handler.CloudModelRespInfo": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateCloudModelReq": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateCloudModelResp": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateOnPremModelReq": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.CreateOnPremModelResp": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetCloudModelResp": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetCloudModelsResp": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pkg_api_rest_handler.CloudModelRespInfo"
+                    }
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetModelsResp": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pkg_api_rest_handler.ModelRespInfo"
+                    }
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetOnPremModelResp": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.GetOnPremModelsResp": {
+            "type": "object",
+            "properties": {
+                "models": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pkg_api_rest_handler.OnPremModelRespInfo"
+                    }
+                }
+            }
+        },
+        "pkg_api_rest_handler.ModelRespInfo": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel",
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.OnPremModelRespInfo": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.ResHTTPVersion": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.ResReadyz": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateCloudModelReq": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateCloudModelResp": {
+            "type": "object",
+            "required": [
+                "cloudInfraModel"
+            ],
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/model.TbMciDynamicReq"
+                },
+                "cloudModelVersion": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateOnPremModelReq": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_rest_handler.UpdateOnPremModelResp": {
+            "type": "object",
+            "required": [
+                "onpremiseInfraModel"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "isCloudModel": {
+                    "type": "boolean"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "isTargetModel": {
+                    "type": "boolean"
+                },
+                "onpremModelVersion": {
+                    "type": "string"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onprem.OnPremInfra"
+                },
+                "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
                 }
             }
         }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,369 +1,5 @@
 basePath: /damselfly
 definitions:
-  handler.CloudModelRespInfo:
-    properties:
-      cloudinfra:
-        $ref: '#/definitions/model.TbMciDynamicReq'
-      cloudmodelversion:
-        type: string
-      createtime:
-        type: string
-      csp:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      region:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-      zone:
-        type: string
-    required:
-    - cloudinfra
-    type: object
-  handler.CreateCloudModelReq:
-    properties:
-      cloudinfra:
-        $ref: '#/definitions/model.TbMciDynamicReq'
-      csp:
-        type: string
-      description:
-        type: string
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      region:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-      zone:
-        type: string
-    required:
-    - cloudinfra
-    type: object
-  handler.CreateCloudModelResp:
-    properties:
-      cloudinfra:
-        $ref: '#/definitions/model.TbMciDynamicReq'
-      cloudmodelversion:
-        type: string
-      createtime:
-        type: string
-      csp:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      region:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-      zone:
-        type: string
-    required:
-    - cloudinfra
-    type: object
-  handler.CreateOnPremModelReq:
-    properties:
-      description:
-        type: string
-      isinitmodel:
-        type: boolean
-      onpreminfra:
-        $ref: '#/definitions/onprem.OnPremInfra'
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-    required:
-    - onpreminfra
-    type: object
-  handler.CreateOnPremModelResp:
-    properties:
-      createtime:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      onpreminfra:
-        $ref: '#/definitions/onprem.OnPremInfra'
-      onpremmodelversion:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-    required:
-    - onpreminfra
-    type: object
-  handler.GetCloudModelResp:
-    properties:
-      cloudinfra:
-        $ref: '#/definitions/model.TbMciDynamicReq'
-      cloudmodelversion:
-        type: string
-      createtime:
-        type: string
-      csp:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      region:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-      zone:
-        type: string
-    required:
-    - cloudinfra
-    type: object
-  handler.GetCloudModelsResp:
-    properties:
-      models:
-        items:
-          $ref: '#/definitions/handler.CloudModelRespInfo'
-        type: array
-    type: object
-  handler.GetOnPremModelResp:
-    properties:
-      createtime:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      onpreminfra:
-        $ref: '#/definitions/onprem.OnPremInfra'
-      onpremmodelversion:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-    required:
-    - onpreminfra
-    type: object
-  handler.GetOnPremModelsResp:
-    properties:
-      models:
-        items:
-          $ref: '#/definitions/handler.OnPremModelRespInfo'
-        type: array
-    type: object
-  handler.OnPremModelRespInfo:
-    properties:
-      createtime:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      onpreminfra:
-        $ref: '#/definitions/onprem.OnPremInfra'
-      onpremmodelversion:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-    required:
-    - onpreminfra
-    type: object
-  handler.ResHTTPVersion:
-    properties:
-      message:
-        type: string
-    type: object
-  handler.ResReadyz:
-    properties:
-      message:
-        type: string
-    type: object
-  handler.UpdateCloudModelReq:
-    properties:
-      cloudinfra:
-        $ref: '#/definitions/model.TbMciDynamicReq'
-      csp:
-        type: string
-      description:
-        type: string
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      region:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-      zone:
-        type: string
-    required:
-    - cloudinfra
-    type: object
-  handler.UpdateCloudModelResp:
-    properties:
-      cloudinfra:
-        $ref: '#/definitions/model.TbMciDynamicReq'
-      cloudmodelversion:
-        type: string
-      createtime:
-        type: string
-      csp:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      region:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-      zone:
-        type: string
-    required:
-    - cloudinfra
-    type: object
-  handler.UpdateOnPremModelReq:
-    properties:
-      description:
-        type: string
-      isinitmodel:
-        type: boolean
-      onpreminfra:
-        $ref: '#/definitions/onprem.OnPremInfra'
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-    required:
-    - onpreminfra
-    type: object
-  handler.UpdateOnPremModelResp:
-    properties:
-      createtime:
-        type: string
-      description:
-        type: string
-      id:
-        type: string
-      iscloudmodel:
-        type: boolean
-      isinitmodel:
-        type: boolean
-      istargetmodel:
-        type: boolean
-      onpreminfra:
-        $ref: '#/definitions/onprem.OnPremInfra'
-      onpremmodelversion:
-        type: string
-      updatetime:
-        type: string
-      userid:
-        type: string
-      usermodelname:
-        type: string
-      usermodelversion:
-        type: string
-    required:
-    - onpreminfra
-    type: object
   model.TbMciDynamicReq:
     properties:
       description:
@@ -660,6 +296,417 @@ definitions:
           $ref: '#/definitions/onprem.RouteProperty'
         type: array
     type: object
+  pkg_api_rest_handler.CloudModelRespInfo:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      cloudModelVersion:
+        type: string
+      createTime:
+        type: string
+      csp:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      region:
+        type: string
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    type: object
+  pkg_api_rest_handler.CreateCloudModelReq:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      csp:
+        type: string
+      description:
+        type: string
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      region:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    type: object
+  pkg_api_rest_handler.CreateCloudModelResp:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      cloudModelVersion:
+        type: string
+      createTime:
+        type: string
+      csp:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      region:
+        type: string
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    type: object
+  pkg_api_rest_handler.CreateOnPremModelReq:
+    properties:
+      description:
+        type: string
+      isInitUserModel:
+        type: boolean
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+    required:
+    - onpremiseInfraModel
+    type: object
+  pkg_api_rest_handler.CreateOnPremModelResp:
+    properties:
+      createTime:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      onpremModelVersion:
+        type: string
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+    required:
+    - onpremiseInfraModel
+    type: object
+  pkg_api_rest_handler.GetCloudModelResp:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      cloudModelVersion:
+        type: string
+      createTime:
+        type: string
+      csp:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      region:
+        type: string
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    type: object
+  pkg_api_rest_handler.GetCloudModelsResp:
+    properties:
+      models:
+        items:
+          $ref: '#/definitions/pkg_api_rest_handler.CloudModelRespInfo'
+        type: array
+    type: object
+  pkg_api_rest_handler.GetModelsResp:
+    properties:
+      models:
+        items:
+          $ref: '#/definitions/pkg_api_rest_handler.ModelRespInfo'
+        type: array
+    type: object
+  pkg_api_rest_handler.GetOnPremModelResp:
+    properties:
+      createTime:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      onpremModelVersion:
+        type: string
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+    required:
+    - onpremiseInfraModel
+    type: object
+  pkg_api_rest_handler.GetOnPremModelsResp:
+    properties:
+      models:
+        items:
+          $ref: '#/definitions/pkg_api_rest_handler.OnPremModelRespInfo'
+        type: array
+    type: object
+  pkg_api_rest_handler.ModelRespInfo:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      cloudModelVersion:
+        type: string
+      createTime:
+        type: string
+      csp:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      onpremModelVersion:
+        type: string
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      region:
+        type: string
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    - onpremiseInfraModel
+    type: object
+  pkg_api_rest_handler.OnPremModelRespInfo:
+    properties:
+      createTime:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      onpremModelVersion:
+        type: string
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+    required:
+    - onpremiseInfraModel
+    type: object
+  pkg_api_rest_handler.ResHTTPVersion:
+    properties:
+      message:
+        type: string
+    type: object
+  pkg_api_rest_handler.ResReadyz:
+    properties:
+      message:
+        type: string
+    type: object
+  pkg_api_rest_handler.UpdateCloudModelReq:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      csp:
+        type: string
+      description:
+        type: string
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      region:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    type: object
+  pkg_api_rest_handler.UpdateCloudModelResp:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/model.TbMciDynamicReq'
+      cloudModelVersion:
+        type: string
+      createTime:
+        type: string
+      csp:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      region:
+        type: string
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
+    required:
+    - cloudInfraModel
+    type: object
+  pkg_api_rest_handler.UpdateOnPremModelReq:
+    properties:
+      description:
+        type: string
+      isInitUserModel:
+        type: boolean
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+    required:
+    - onpremiseInfraModel
+    type: object
+  pkg_api_rest_handler.UpdateOnPremModelResp:
+    properties:
+      createTime:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isCloudModel:
+        type: boolean
+      isInitUserModel:
+        type: boolean
+      isTargetModel:
+        type: boolean
+      onpremModelVersion:
+        type: string
+      onpremiseInfraModel:
+        $ref: '#/definitions/onprem.OnPremInfra'
+      updateTime:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+    required:
+    - onpremiseInfraModel
+    type: object
 info:
   contact:
     email: contact-to-cloud-barista@googlegroups.com
@@ -683,7 +730,7 @@ paths:
         "200":
           description: (sample) This is a list of models
           schema:
-            $ref: '#/definitions/handler.GetCloudModelsResp'
+            $ref: '#/definitions/pkg_api_rest_handler.GetCloudModelsResp'
         "404":
           description: model not found
           schema:
@@ -701,7 +748,7 @@ paths:
         name: Model
         required: true
         schema:
-          $ref: '#/definitions/handler.CreateCloudModelReq'
+          $ref: '#/definitions/pkg_api_rest_handler.CreateCloudModelReq'
       produces:
       - application/json
       responses:
@@ -709,7 +756,7 @@ paths:
           description: (Sample) This is a sample description for success response
             in Swagger UI
           schema:
-            $ref: '#/definitions/handler.CreateCloudModelResp'
+            $ref: '#/definitions/pkg_api_rest_handler.CreateCloudModelResp'
         "400":
           description: Invalid Request
           schema:
@@ -762,7 +809,7 @@ paths:
         "200":
           description: (Sample) a model
           schema:
-            $ref: '#/definitions/handler.GetCloudModelResp'
+            $ref: '#/definitions/pkg_api_rest_handler.GetCloudModelResp'
         "404":
           description: model not found
           schema:
@@ -785,7 +832,7 @@ paths:
         name: Model
         required: true
         schema:
-          $ref: '#/definitions/handler.UpdateCloudModelReq'
+          $ref: '#/definitions/pkg_api_rest_handler.UpdateCloudModelReq'
       produces:
       - application/json
       responses:
@@ -793,7 +840,7 @@ paths:
           description: (Sample) This is a sample description for success response
             in Swagger UI
           schema:
-            $ref: '#/definitions/handler.UpdateCloudModelResp'
+            $ref: '#/definitions/pkg_api_rest_handler.UpdateCloudModelResp'
         "400":
           description: Invalid Request
           schema:
@@ -813,18 +860,43 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handler.ResHTTPVersion'
+            $ref: '#/definitions/pkg_api_rest_handler.ResHTTPVersion'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/handler.ResHTTPVersion'
+            $ref: '#/definitions/pkg_api_rest_handler.ResHTTPVersion'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/handler.ResHTTPVersion'
+            $ref: '#/definitions/pkg_api_rest_handler.ResHTTPVersion'
       summary: Check HTTP version of incoming request
       tags:
       - '[Admin] System management'
+  /model/{isTargetModel}:
+    get:
+      consumes:
+      - application/json
+      description: Get a list of all user models.
+      parameters:
+      - description: Is TargetModel ?
+        in: path
+        name: isTargetModel
+        required: true
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: (sample) This is a list of models
+          schema:
+            $ref: '#/definitions/pkg_api_rest_handler.GetModelsResp'
+        "404":
+          description: model not found
+          schema:
+            type: object
+      summary: Get a list of all user models
+      tags:
+      - '[API] Migration Models'
   /onpremmodel:
     get:
       consumes:
@@ -836,7 +908,7 @@ paths:
         "200":
           description: (sample) This is a list of models
           schema:
-            $ref: '#/definitions/handler.GetOnPremModelsResp'
+            $ref: '#/definitions/pkg_api_rest_handler.GetOnPremModelsResp'
         "404":
           description: model not found
           schema:
@@ -854,7 +926,7 @@ paths:
         name: Model
         required: true
         schema:
-          $ref: '#/definitions/handler.CreateOnPremModelReq'
+          $ref: '#/definitions/pkg_api_rest_handler.CreateOnPremModelReq'
       produces:
       - application/json
       responses:
@@ -862,7 +934,7 @@ paths:
           description: (Sample) This is a sample description for success response
             in Swagger UI
           schema:
-            $ref: '#/definitions/handler.CreateOnPremModelResp'
+            $ref: '#/definitions/pkg_api_rest_handler.CreateOnPremModelResp'
         "400":
           description: Invalid Request
           schema:
@@ -915,7 +987,7 @@ paths:
         "200":
           description: (Sample) a model
           schema:
-            $ref: '#/definitions/handler.GetOnPremModelResp'
+            $ref: '#/definitions/pkg_api_rest_handler.GetOnPremModelResp'
         "404":
           description: model not found
           schema:
@@ -938,7 +1010,7 @@ paths:
         name: Model
         required: true
         schema:
-          $ref: '#/definitions/handler.UpdateOnPremModelReq'
+          $ref: '#/definitions/pkg_api_rest_handler.UpdateOnPremModelReq'
       produces:
       - application/json
       responses:
@@ -946,7 +1018,7 @@ paths:
           description: (Sample) This is a sample description for success response
             in Swagger UI
           schema:
-            $ref: '#/definitions/handler.UpdateOnPremModelResp'
+            $ref: '#/definitions/pkg_api_rest_handler.UpdateOnPremModelResp'
         "400":
           description: Invalid Request
           schema:
@@ -965,11 +1037,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handler.ResReadyz'
+            $ref: '#/definitions/pkg_api_rest_handler.ResReadyz'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/handler.ResReadyz'
+            $ref: '#/definitions/pkg_api_rest_handler.ResReadyz'
       summary: Check Damselfly is ready
       tags:
       - '[Admin] System management'

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -167,6 +167,9 @@ func RunServer(port string) {
 	// for model API, set a router group which has "/damselfly/model" as prefix
 	gModel := groupBase.Group("")
 	// gModel := groupBase.Group("/model")
+
+	gModel.GET("/model/:isTargetModel", handler.GetModels)
+
 	gModel.POST("/onpremmodel", handler.CreateOnPremModel)
 	gModel.GET("/onpremmodel", handler.GetOnPremModels)
 	gModel.GET("/onpremmodel/:id", handler.GetOnPremModel)


### PR DESCRIPTION
- Add features to search all user models by distinguishing between source models and target models
  (with 'isTargetModel' parameter)
  - Related issue) https://github.com/cloud-barista/cm-damselfly/issues/15#issuecomment-2428235104
- Update parameters name in structure like the imported model structures below.
  - tbmodel "github.com/cloud-barista/cb-tumblebug/src/core/model"
  - onprem "github.com/cloud-barista/cm-model/infra/onprem" 
