### PR TITLE
Bump cm-grasshopper/smdl to v0.1.1 for required_packages

### DIFF
--- a/cmd/cm-damselfly/go.mod
+++ b/cmd/cm-damselfly/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cloud-barista/cm-beetle/imdl v0.1.6
-	github.com/cloud-barista/cm-grasshopper/smdl v0.1.0
+	github.com/cloud-barista/cm-grasshopper/smdl v0.1.1
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/rs/zerolog v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/cloud-barista/cm-beetle/imdl v0.1.6
-	github.com/cloud-barista/cm-grasshopper/smdl v0.1.0
+	github.com/cloud-barista/cm-grasshopper/smdl v0.1.1
 	github.com/google/uuid v1.6.0
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/cloud-barista/cm-beetle/imdl v0.1.6 h1:yez4kv3dqvPytroryRaobbMmjT2tMTy4eheF+e1mcO4=
 github.com/cloud-barista/cm-beetle/imdl v0.1.6/go.mod h1:RfpzPB67XRW5TDGs5f4Cv/W/zJ3c+eU8eV291oj+ns0=
-github.com/cloud-barista/cm-grasshopper/smdl v0.1.0 h1:mS5s+PKpuW6EjZnLf6fcNEYZTDX5C54rvBgqB01FGj4=
-github.com/cloud-barista/cm-grasshopper/smdl v0.1.0/go.mod h1:5bC1RZTSTuQo1YdlOTf+H7Zz2x8TpQrOPpdnG/2y/Hk=
+github.com/cloud-barista/cm-grasshopper/smdl v0.1.1 h1:RxUaiu9LWqHUwjA2yUoKuHzhpUZlm4ADxnAvk55pLsg=
+github.com/cloud-barista/cm-grasshopper/smdl v0.1.1/go.mod h1:WORfvOxkJr+NhRPCsJvkntzTEY/aG9JeuKFXKEBemAY=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
damselfly referenced the software model at `cm-grasshopper/smdl v0.1.0`, which lacks the `required_packages` field added in v0.1.1. cm-honeybee and cm-grasshopper already use v0.1.1, so damselfly's stored/returned software user models dropped `required_packages` and diverged from the rest of the pipeline.

Bump smdl to v0.1.1 to align the software model.

- `go.mod`, `cmd/cm-damselfly/go.mod`: smdl v0.1.0 → v0.1.1