### PR TITLE
Add feature to Manage Infra Migration User Models through Unified API

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -310,6 +310,329 @@ const docTemplate = `{
                 }
             }
         },
+        "/infra-model": {
+            "get": {
+                "description": "Get a list of infra migration user models filtered by model type and source/target classification.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Get a list of infra migration user models (on-premise or cloud)",
+                "operationId": "GetInfraModels",
+                "parameters": [
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to retrieve",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "description": "Whether to retrieve target models (true) or source models (false)",
+                        "name": "isTargetModel",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully obtained infra migration user models",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new infra migration user model. Use 'modelType' to select on-premise or cloud, and 'isTargetModel' to select source or target model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Create a new infra migration user model (on-premise or cloud)",
+                "operationId": "CreateInfraModel",
+                "parameters": [
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to create",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "description": "Whether to create a target model (true) or a source model (false)",
+                        "name": "isTargetModel",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Infra model information",
+                        "name": "Model",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.CreateInfraModelReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successfully created the infra migration user model",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/infra-model/{id}": {
+            "get": {
+                "description": "Get a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Get a specific infra migration user model (on-premise or cloud)",
+                "operationId": "GetInfraModel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to retrieve",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully obtained the infra migration user model",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Update a specific infra migration user model (on-premise or cloud)",
+                "operationId": "UpdateInfraModel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to update",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Infra model information to update",
+                        "name": "Model",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.CreateInfraModelReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated the infra migration user model",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a specific infra migration user model by ID. Works for both on-premise and cloud models without requiring the caller to specify the model type.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Delete a specific infra migration user model (on-premise or cloud)",
+                "operationId": "DeleteInfraModel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted the infra migration user model",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/model/version": {
             "get": {
                 "description": "Get the versions of all models(schemata of on-premise/cloud/software migration models)",
@@ -1302,6 +1625,10 @@ const docTemplate = `{
                     "description": "vm|k8s|kubernetes|container, etc.",
                     "type": "string"
                 },
+                "isBasicGpuImage": {
+                    "type": "boolean",
+                    "default": false
+                },
                 "isBasicImage": {
                     "type": "boolean",
                     "default": false
@@ -1537,6 +1864,81 @@ const docTemplate = `{
                 }
             }
         },
+        "cloudmodel.NlbHealthCheckerReq": {
+            "type": "object",
+            "properties": {
+                "interval": {
+                    "description": "Health check interval in seconds",
+                    "type": "integer"
+                },
+                "threshold": {
+                    "description": "Unhealthy threshold count",
+                    "type": "integer"
+                },
+                "timeout": {
+                    "description": "Health check timeout in seconds",
+                    "type": "integer"
+                }
+            }
+        },
+        "cloudmodel.NlbListenerReq": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "description": "\"1\"–\"65535\"",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "TCP | UDP",
+                    "type": "string"
+                }
+            }
+        },
+        "cloudmodel.NlbReq": {
+            "type": "object",
+            "properties": {
+                "cspResourceId": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "healthChecker": {
+                    "$ref": "#/definitions/cloudmodel.NlbHealthCheckerReq"
+                },
+                "listener": {
+                    "$ref": "#/definitions/cloudmodel.NlbListenerReq"
+                },
+                "scope": {
+                    "description": "REGION | GLOBAL",
+                    "type": "string"
+                },
+                "targetGroup": {
+                    "$ref": "#/definitions/cloudmodel.NlbTargetGroupReq"
+                },
+                "type": {
+                    "description": "PUBLIC | INTERNAL",
+                    "type": "string"
+                }
+            }
+        },
+        "cloudmodel.NlbTargetGroupReq": {
+            "type": "object",
+            "properties": {
+                "nodeGroupId": {
+                    "description": "NodeGroup ID in the target Infra",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Backend port",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "TCP | HTTP | HTTPS",
+                    "type": "string"
+                }
+            }
+        },
         "cloudmodel.OSArchitecture": {
             "type": "string",
             "enum": [
@@ -1591,6 +1993,12 @@ const docTemplate = `{
                 },
                 "targetInfra": {
                     "$ref": "#/definitions/cloudmodel.InfraReq"
+                },
+                "targetNlbList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.NlbReq"
+                    }
                 },
                 "targetOsImageList": {
                     "type": "array",
@@ -2028,6 +2436,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.CreateInfraModelReq": {
+            "type": "object",
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/cloudmodel.RecommendedInfra"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                },
+                "region": {
                     "type": "string"
                 },
                 "userId": {
@@ -3362,6 +3805,116 @@ const docTemplate = `{
                 }
             }
         },
+        "onpremisemodel.NlbBackendProperty": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "description": "\"roundrobin\" | \"leastconn\" | \"source\" (note only)",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Backend section name",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "\"tcp\" | \"http\"",
+                    "type": "string"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/onpremisemodel.NlbServerProperty"
+                    }
+                }
+            }
+        },
+        "onpremisemodel.NlbHealthCheckProperty": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "description": "seconds; default 10",
+                    "type": "integer"
+                },
+                "port": {
+                    "description": "0 = same as server port",
+                    "type": "integer"
+                },
+                "protocol": {
+                    "description": "\"tcp\" | \"http\"",
+                    "type": "string"
+                },
+                "threshold": {
+                    "description": "default 3",
+                    "type": "integer"
+                },
+                "timeout": {
+                    "description": "seconds; default 10",
+                    "type": "integer"
+                }
+            }
+        },
+        "onpremisemodel.NlbListenerProperty": {
+            "type": "object",
+            "properties": {
+                "bindAddress": {
+                    "description": "\"*\" = all interfaces (→ PUBLIC), specific IP = INTERNAL",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Listener port (1–65535)",
+                    "type": "integer"
+                },
+                "protocol": {
+                    "description": "\"tcp\" | \"udp\"",
+                    "type": "string"
+                }
+            }
+        },
+        "onpremisemodel.NlbProperty": {
+            "type": "object",
+            "properties": {
+                "backend": {
+                    "$ref": "#/definitions/onpremisemodel.NlbBackendProperty"
+                },
+                "healthCheck": {
+                    "$ref": "#/definitions/onpremisemodel.NlbHealthCheckProperty"
+                },
+                "hostMachineId": {
+                    "description": "MachineId of the node running HAProxy",
+                    "type": "string"
+                },
+                "listener": {
+                    "$ref": "#/definitions/onpremisemodel.NlbListenerProperty"
+                },
+                "software": {
+                    "description": "\"haproxy\"",
+                    "type": "string"
+                }
+            }
+        },
+        "onpremisemodel.NlbServerProperty": {
+            "type": "object",
+            "properties": {
+                "ip": {
+                    "description": "Server IP; used for IP correlation at recommendation time",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Server port",
+                    "type": "integer"
+                },
+                "weight": {
+                    "description": "Traffic weight (reference only)",
+                    "type": "integer"
+                }
+            }
+        },
         "onpremisemodel.NodeProperty": {
             "type": "object",
             "properties": {
@@ -3431,6 +3984,13 @@ const docTemplate = `{
                 },
                 "network": {
                     "$ref": "#/definitions/onpremisemodel.NetworkProperty"
+                },
+                "nlbs": {
+                    "description": "NLBs holds on-premise NLB instances (HAProxy-based), one entry per frontend-backend pair.\nPopulated by cm-honeybee when HAProxy is detected on a node.\nUsed exclusively by POST /recommendation/infraWithNlb; ignored by POST /recommendation/infra.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/onpremisemodel.NlbProperty"
+                    }
                 },
                 "nodes": {
                     "type": "array",
@@ -3561,6 +4121,10 @@ const docTemplate = `{
                 "is_wine": {
                     "type": "boolean"
                 },
+                "launch_type": {
+                    "description": "Launch provenance: how the software was started on the source host.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3570,6 +4134,31 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "pid_file": {
+                    "description": "PIDFile= for forking services",
+                    "type": "string"
+                },
+                "required_packages": {
+                    "description": "OS packages the target must install (package-provided linked libs)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "service_type": {
+                    "description": "systemd Type= (\"simple\"|\"forking\"|...)",
+                    "type": "string"
+                },
+                "systemd_enabled": {
+                    "type": "boolean"
+                },
+                "systemd_unit_name": {
+                    "type": "string"
+                },
+                "systemd_unit_path": {
+                    "description": "source unit file path (to copy)",
+                    "type": "string"
+                },
                 "uids": {
                     "type": "array",
                     "items": {
@@ -3577,6 +4166,14 @@ const docTemplate = `{
                     }
                 },
                 "version": {
+                    "type": "string"
+                },
+                "wine_prefix": {
+                    "description": "WINEPREFIX bottle dir (Wine apps)",
+                    "type": "string"
+                },
+                "working_directory": {
+                    "description": "used to synthesize a unit",
                     "type": "string"
                 }
             }
@@ -3627,6 +4224,10 @@ const docTemplate = `{
                 "is_wine": {
                     "type": "boolean"
                 },
+                "launch_type": {
+                    "description": "Launch provenance: how the software was started on the source host.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3639,6 +4240,28 @@ const docTemplate = `{
                 "order": {
                     "type": "integer"
                 },
+                "pid_file": {
+                    "type": "string"
+                },
+                "required_packages": {
+                    "description": "OS packages the target must install (package-provided linked libs)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "service_type": {
+                    "type": "string"
+                },
+                "systemd_enabled": {
+                    "type": "boolean"
+                },
+                "systemd_unit_name": {
+                    "type": "string"
+                },
+                "systemd_unit_path": {
+                    "type": "string"
+                },
                 "uids": {
                     "type": "array",
                     "items": {
@@ -3646,6 +4269,12 @@ const docTemplate = `{
                     }
                 },
                 "version": {
+                    "type": "string"
+                },
+                "wine_prefix": {
+                    "type": "string"
+                },
+                "working_directory": {
                     "type": "string"
                 }
             }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -303,6 +303,329 @@
                 }
             }
         },
+        "/infra-model": {
+            "get": {
+                "description": "Get a list of infra migration user models filtered by model type and source/target classification.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Get a list of infra migration user models (on-premise or cloud)",
+                "operationId": "GetInfraModels",
+                "parameters": [
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to retrieve",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "description": "Whether to retrieve target models (true) or source models (false)",
+                        "name": "isTargetModel",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully obtained infra migration user models",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new infra migration user model. Use 'modelType' to select on-premise or cloud, and 'isTargetModel' to select source or target model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Create a new infra migration user model (on-premise or cloud)",
+                "operationId": "CreateInfraModel",
+                "parameters": [
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to create",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "description": "Whether to create a target model (true) or a source model (false)",
+                        "name": "isTargetModel",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Infra model information",
+                        "name": "Model",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.CreateInfraModelReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successfully created the infra migration user model",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/infra-model/{id}": {
+            "get": {
+                "description": "Get a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Get a specific infra migration user model (on-premise or cloud)",
+                "operationId": "GetInfraModel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to retrieve",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully obtained the infra migration user model",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Update a specific infra migration user model (on-premise or cloud)",
+                "operationId": "UpdateInfraModel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "onprem",
+                            "cloud"
+                        ],
+                        "type": "string",
+                        "description": "Type of infra model to update",
+                        "name": "modelType",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Infra model information to update",
+                        "name": "Model",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.CreateInfraModelReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated the infra migration user model",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a specific infra migration user model by ID. Works for both on-premise and cloud models without requiring the caller to specify the model type.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[API] Migration User Models"
+                ],
+                "summary": "Delete a specific infra migration user model (on-premise or cloud)",
+                "operationId": "DeleteInfraModel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Model ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully deleted the infra migration user model",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Model Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/model/version": {
             "get": {
                 "description": "Get the versions of all models(schemata of on-premise/cloud/software migration models)",
@@ -1295,6 +1618,10 @@
                     "description": "vm|k8s|kubernetes|container, etc.",
                     "type": "string"
                 },
+                "isBasicGpuImage": {
+                    "type": "boolean",
+                    "default": false
+                },
                 "isBasicImage": {
                     "type": "boolean",
                     "default": false
@@ -1530,6 +1857,81 @@
                 }
             }
         },
+        "cloudmodel.NlbHealthCheckerReq": {
+            "type": "object",
+            "properties": {
+                "interval": {
+                    "description": "Health check interval in seconds",
+                    "type": "integer"
+                },
+                "threshold": {
+                    "description": "Unhealthy threshold count",
+                    "type": "integer"
+                },
+                "timeout": {
+                    "description": "Health check timeout in seconds",
+                    "type": "integer"
+                }
+            }
+        },
+        "cloudmodel.NlbListenerReq": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "description": "\"1\"–\"65535\"",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "TCP | UDP",
+                    "type": "string"
+                }
+            }
+        },
+        "cloudmodel.NlbReq": {
+            "type": "object",
+            "properties": {
+                "cspResourceId": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "healthChecker": {
+                    "$ref": "#/definitions/cloudmodel.NlbHealthCheckerReq"
+                },
+                "listener": {
+                    "$ref": "#/definitions/cloudmodel.NlbListenerReq"
+                },
+                "scope": {
+                    "description": "REGION | GLOBAL",
+                    "type": "string"
+                },
+                "targetGroup": {
+                    "$ref": "#/definitions/cloudmodel.NlbTargetGroupReq"
+                },
+                "type": {
+                    "description": "PUBLIC | INTERNAL",
+                    "type": "string"
+                }
+            }
+        },
+        "cloudmodel.NlbTargetGroupReq": {
+            "type": "object",
+            "properties": {
+                "nodeGroupId": {
+                    "description": "NodeGroup ID in the target Infra",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Backend port",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "TCP | HTTP | HTTPS",
+                    "type": "string"
+                }
+            }
+        },
         "cloudmodel.OSArchitecture": {
             "type": "string",
             "enum": [
@@ -1584,6 +1986,12 @@
                 },
                 "targetInfra": {
                     "$ref": "#/definitions/cloudmodel.InfraReq"
+                },
+                "targetNlbList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/cloudmodel.NlbReq"
+                    }
                 },
                 "targetOsImageList": {
                     "type": "array",
@@ -2021,6 +2429,41 @@
                     "type": "string"
                 },
                 "updateTime": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "string"
+                },
+                "userModelName": {
+                    "type": "string"
+                },
+                "userModelVersion": {
+                    "type": "string"
+                },
+                "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.CreateInfraModelReq": {
+            "type": "object",
+            "properties": {
+                "cloudInfraModel": {
+                    "$ref": "#/definitions/cloudmodel.RecommendedInfra"
+                },
+                "csp": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isInitUserModel": {
+                    "type": "boolean"
+                },
+                "onpremiseInfraModel": {
+                    "$ref": "#/definitions/onpremisemodel.OnpremInfra"
+                },
+                "region": {
                     "type": "string"
                 },
                 "userId": {
@@ -3355,6 +3798,116 @@
                 }
             }
         },
+        "onpremisemodel.NlbBackendProperty": {
+            "type": "object",
+            "properties": {
+                "balance": {
+                    "description": "\"roundrobin\" | \"leastconn\" | \"source\" (note only)",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Backend section name",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "\"tcp\" | \"http\"",
+                    "type": "string"
+                },
+                "servers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/onpremisemodel.NlbServerProperty"
+                    }
+                }
+            }
+        },
+        "onpremisemodel.NlbHealthCheckProperty": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "interval": {
+                    "description": "seconds; default 10",
+                    "type": "integer"
+                },
+                "port": {
+                    "description": "0 = same as server port",
+                    "type": "integer"
+                },
+                "protocol": {
+                    "description": "\"tcp\" | \"http\"",
+                    "type": "string"
+                },
+                "threshold": {
+                    "description": "default 3",
+                    "type": "integer"
+                },
+                "timeout": {
+                    "description": "seconds; default 10",
+                    "type": "integer"
+                }
+            }
+        },
+        "onpremisemodel.NlbListenerProperty": {
+            "type": "object",
+            "properties": {
+                "bindAddress": {
+                    "description": "\"*\" = all interfaces (→ PUBLIC), specific IP = INTERNAL",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Listener port (1–65535)",
+                    "type": "integer"
+                },
+                "protocol": {
+                    "description": "\"tcp\" | \"udp\"",
+                    "type": "string"
+                }
+            }
+        },
+        "onpremisemodel.NlbProperty": {
+            "type": "object",
+            "properties": {
+                "backend": {
+                    "$ref": "#/definitions/onpremisemodel.NlbBackendProperty"
+                },
+                "healthCheck": {
+                    "$ref": "#/definitions/onpremisemodel.NlbHealthCheckProperty"
+                },
+                "hostMachineId": {
+                    "description": "MachineId of the node running HAProxy",
+                    "type": "string"
+                },
+                "listener": {
+                    "$ref": "#/definitions/onpremisemodel.NlbListenerProperty"
+                },
+                "software": {
+                    "description": "\"haproxy\"",
+                    "type": "string"
+                }
+            }
+        },
+        "onpremisemodel.NlbServerProperty": {
+            "type": "object",
+            "properties": {
+                "ip": {
+                    "description": "Server IP; used for IP correlation at recommendation time",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Server port",
+                    "type": "integer"
+                },
+                "weight": {
+                    "description": "Traffic weight (reference only)",
+                    "type": "integer"
+                }
+            }
+        },
         "onpremisemodel.NodeProperty": {
             "type": "object",
             "properties": {
@@ -3424,6 +3977,13 @@
                 },
                 "network": {
                     "$ref": "#/definitions/onpremisemodel.NetworkProperty"
+                },
+                "nlbs": {
+                    "description": "NLBs holds on-premise NLB instances (HAProxy-based), one entry per frontend-backend pair.\nPopulated by cm-honeybee when HAProxy is detected on a node.\nUsed exclusively by POST /recommendation/infraWithNlb; ignored by POST /recommendation/infra.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/onpremisemodel.NlbProperty"
+                    }
                 },
                 "nodes": {
                     "type": "array",
@@ -3554,6 +4114,10 @@
                 "is_wine": {
                     "type": "boolean"
                 },
+                "launch_type": {
+                    "description": "Launch provenance: how the software was started on the source host.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3563,6 +4127,31 @@
                         "type": "string"
                     }
                 },
+                "pid_file": {
+                    "description": "PIDFile= for forking services",
+                    "type": "string"
+                },
+                "required_packages": {
+                    "description": "OS packages the target must install (package-provided linked libs)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "service_type": {
+                    "description": "systemd Type= (\"simple\"|\"forking\"|...)",
+                    "type": "string"
+                },
+                "systemd_enabled": {
+                    "type": "boolean"
+                },
+                "systemd_unit_name": {
+                    "type": "string"
+                },
+                "systemd_unit_path": {
+                    "description": "source unit file path (to copy)",
+                    "type": "string"
+                },
                 "uids": {
                     "type": "array",
                     "items": {
@@ -3570,6 +4159,14 @@
                     }
                 },
                 "version": {
+                    "type": "string"
+                },
+                "wine_prefix": {
+                    "description": "WINEPREFIX bottle dir (Wine apps)",
+                    "type": "string"
+                },
+                "working_directory": {
+                    "description": "used to synthesize a unit",
                     "type": "string"
                 }
             }
@@ -3620,6 +4217,10 @@
                 "is_wine": {
                     "type": "boolean"
                 },
+                "launch_type": {
+                    "description": "Launch provenance: how the software was started on the source host.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3632,6 +4233,28 @@
                 "order": {
                     "type": "integer"
                 },
+                "pid_file": {
+                    "type": "string"
+                },
+                "required_packages": {
+                    "description": "OS packages the target must install (package-provided linked libs)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "service_type": {
+                    "type": "string"
+                },
+                "systemd_enabled": {
+                    "type": "boolean"
+                },
+                "systemd_unit_name": {
+                    "type": "string"
+                },
+                "systemd_unit_path": {
+                    "type": "string"
+                },
                 "uids": {
                     "type": "array",
                     "items": {
@@ -3639,6 +4262,12 @@
                     }
                 },
                 "version": {
+                    "type": "string"
+                },
+                "wine_prefix": {
+                    "type": "string"
+                },
+                "working_directory": {
                     "type": "string"
                 }
             }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -161,6 +161,9 @@ definitions:
       infraType:
         description: vm|k8s|kubernetes|container, etc.
         type: string
+      isBasicGpuImage:
+        default: false
+        type: boolean
       isBasicImage:
         default: false
         type: boolean
@@ -345,6 +348,58 @@ definitions:
       value:
         type: string
     type: object
+  cloudmodel.NlbHealthCheckerReq:
+    properties:
+      interval:
+        description: Health check interval in seconds
+        type: integer
+      threshold:
+        description: Unhealthy threshold count
+        type: integer
+      timeout:
+        description: Health check timeout in seconds
+        type: integer
+    type: object
+  cloudmodel.NlbListenerReq:
+    properties:
+      port:
+        description: '"1"–"65535"'
+        type: string
+      protocol:
+        description: TCP | UDP
+        type: string
+    type: object
+  cloudmodel.NlbReq:
+    properties:
+      cspResourceId:
+        type: string
+      description:
+        type: string
+      healthChecker:
+        $ref: '#/definitions/cloudmodel.NlbHealthCheckerReq'
+      listener:
+        $ref: '#/definitions/cloudmodel.NlbListenerReq'
+      scope:
+        description: REGION | GLOBAL
+        type: string
+      targetGroup:
+        $ref: '#/definitions/cloudmodel.NlbTargetGroupReq'
+      type:
+        description: PUBLIC | INTERNAL
+        type: string
+    type: object
+  cloudmodel.NlbTargetGroupReq:
+    properties:
+      nodeGroupId:
+        description: NodeGroup ID in the target Infra
+        type: string
+      port:
+        description: Backend port
+        type: string
+      protocol:
+        description: TCP | HTTP | HTTPS
+        type: string
+    type: object
   cloudmodel.OSArchitecture:
     enum:
     - arm32
@@ -389,6 +444,10 @@ definitions:
         $ref: '#/definitions/cloudmodel.CloudProperty'
       targetInfra:
         $ref: '#/definitions/cloudmodel.InfraReq'
+      targetNlbList:
+        items:
+          $ref: '#/definitions/cloudmodel.NlbReq'
+        type: array
       targetOsImageList:
         items:
           $ref: '#/definitions/cloudmodel.ImageInfo'
@@ -701,6 +760,29 @@ definitions:
         type: string
     required:
     - cloudInfraModel
+    type: object
+  handler.CreateInfraModelReq:
+    properties:
+      cloudInfraModel:
+        $ref: '#/definitions/cloudmodel.RecommendedInfra'
+      csp:
+        type: string
+      description:
+        type: string
+      isInitUserModel:
+        type: boolean
+      onpremiseInfraModel:
+        $ref: '#/definitions/onpremisemodel.OnpremInfra'
+      region:
+        type: string
+      userId:
+        type: string
+      userModelName:
+        type: string
+      userModelVersion:
+        type: string
+      zone:
+        type: string
     type: object
   handler.CreateOnPremModelReq:
     properties:
@@ -1587,6 +1669,83 @@ definitions:
         - $ref: '#/definitions/onpremisemodel.NetworkDetail'
         description: TBD
     type: object
+  onpremisemodel.NlbBackendProperty:
+    properties:
+      balance:
+        description: '"roundrobin" | "leastconn" | "source" (note only)'
+        type: string
+      name:
+        description: Backend section name
+        type: string
+      protocol:
+        description: '"tcp" | "http"'
+        type: string
+      servers:
+        items:
+          $ref: '#/definitions/onpremisemodel.NlbServerProperty'
+        type: array
+    type: object
+  onpremisemodel.NlbHealthCheckProperty:
+    properties:
+      enabled:
+        type: boolean
+      interval:
+        description: seconds; default 10
+        type: integer
+      port:
+        description: 0 = same as server port
+        type: integer
+      protocol:
+        description: '"tcp" | "http"'
+        type: string
+      threshold:
+        description: default 3
+        type: integer
+      timeout:
+        description: seconds; default 10
+        type: integer
+    type: object
+  onpremisemodel.NlbListenerProperty:
+    properties:
+      bindAddress:
+        description: '"*" = all interfaces (→ PUBLIC), specific IP = INTERNAL'
+        type: string
+      port:
+        description: Listener port (1–65535)
+        type: integer
+      protocol:
+        description: '"tcp" | "udp"'
+        type: string
+    type: object
+  onpremisemodel.NlbProperty:
+    properties:
+      backend:
+        $ref: '#/definitions/onpremisemodel.NlbBackendProperty'
+      healthCheck:
+        $ref: '#/definitions/onpremisemodel.NlbHealthCheckProperty'
+      hostMachineId:
+        description: MachineId of the node running HAProxy
+        type: string
+      listener:
+        $ref: '#/definitions/onpremisemodel.NlbListenerProperty'
+      software:
+        description: '"haproxy"'
+        type: string
+    type: object
+  onpremisemodel.NlbServerProperty:
+    properties:
+      ip:
+        description: Server IP; used for IP correlation at recommendation time
+        type: string
+      name:
+        type: string
+      port:
+        description: Server port
+        type: integer
+      weight:
+        description: Traffic weight (reference only)
+        type: integer
+    type: object
   onpremisemodel.NodeProperty:
     properties:
       cpu:
@@ -1632,6 +1791,14 @@ definitions:
           (e.g., OpenShift, Rancher) are needed.'
       network:
         $ref: '#/definitions/onpremisemodel.NetworkProperty'
+      nlbs:
+        description: |-
+          NLBs holds on-premise NLB instances (HAProxy-based), one entry per frontend-backend pair.
+          Populated by cm-honeybee when HAProxy is detected on a node.
+          Used exclusively by POST /recommendation/infraWithNlb; ignored by POST /recommendation/infra.
+        items:
+          $ref: '#/definitions/onpremisemodel.NlbProperty'
+        type: array
       nodes:
         items:
           $ref: '#/definitions/onpremisemodel.NodeProperty'
@@ -1720,17 +1887,46 @@ definitions:
         type: array
       is_wine:
         type: boolean
+      launch_type:
+        description: 'Launch provenance: how the software was started on the source
+          host.'
+        type: string
       name:
         type: string
       needed_libraries:
         items:
           type: string
         type: array
+      pid_file:
+        description: PIDFile= for forking services
+        type: string
+      required_packages:
+        description: OS packages the target must install (package-provided linked
+          libs)
+        items:
+          type: string
+        type: array
+      service_type:
+        description: systemd Type= ("simple"|"forking"|...)
+        type: string
+      systemd_enabled:
+        type: boolean
+      systemd_unit_name:
+        type: string
+      systemd_unit_path:
+        description: source unit file path (to copy)
+        type: string
       uids:
         items:
           type: integer
         type: array
       version:
+        type: string
+      wine_prefix:
+        description: WINEPREFIX bottle dir (Wine apps)
+        type: string
+      working_directory:
+        description: used to synthesize a unit
         type: string
     required:
     - envs
@@ -1765,6 +1961,10 @@ definitions:
         type: array
       is_wine:
         type: boolean
+      launch_type:
+        description: 'Launch provenance: how the software was started on the source
+          host.'
+        type: string
       name:
         type: string
       needed_libraries:
@@ -1773,11 +1973,31 @@ definitions:
         type: array
       order:
         type: integer
+      pid_file:
+        type: string
+      required_packages:
+        description: OS packages the target must install (package-provided linked
+          libs)
+        items:
+          type: string
+        type: array
+      service_type:
+        type: string
+      systemd_enabled:
+        type: boolean
+      systemd_unit_name:
+        type: string
+      systemd_unit_path:
+        type: string
       uids:
         items:
           type: integer
         type: array
       version:
+        type: string
+      wine_prefix:
+        type: string
+      working_directory:
         type: string
     required:
     - envs
@@ -2358,6 +2578,232 @@ paths:
       summary: Check HTTP version of incoming request
       tags:
       - '[Admin] System management'
+  /infra-model:
+    get:
+      consumes:
+      - application/json
+      description: Get a list of infra migration user models filtered by model type
+        and source/target classification.
+      operationId: GetInfraModels
+      parameters:
+      - description: Type of infra model to retrieve
+        enum:
+        - onprem
+        - cloud
+        in: query
+        name: modelType
+        required: true
+        type: string
+      - description: Whether to retrieve target models (true) or source models (false)
+        enum:
+        - "true"
+        - "false"
+        in: query
+        name: isTargetModel
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully obtained infra migration user models
+          schema:
+            items:
+              additionalProperties: true
+              type: object
+            type: array
+        "400":
+          description: Invalid request parameter
+          schema:
+            $ref: '#/definitions/model.Response'
+        "404":
+          description: Model Not Found
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Get a list of infra migration user models (on-premise or cloud)
+      tags:
+      - '[API] Migration User Models'
+    post:
+      consumes:
+      - application/json
+      description: Create a new infra migration user model. Use 'modelType' to select
+        on-premise or cloud, and 'isTargetModel' to select source or target model.
+      operationId: CreateInfraModel
+      parameters:
+      - description: Type of infra model to create
+        enum:
+        - onprem
+        - cloud
+        in: query
+        name: modelType
+        required: true
+        type: string
+      - description: Whether to create a target model (true) or a source model (false)
+        enum:
+        - "true"
+        - "false"
+        in: query
+        name: isTargetModel
+        required: true
+        type: string
+      - description: Infra model information
+        in: body
+        name: Model
+        required: true
+        schema:
+          $ref: '#/definitions/handler.CreateInfraModelReq'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Successfully created the infra migration user model
+          schema:
+            type: object
+        "400":
+          description: Invalid request parameter
+          schema:
+            $ref: '#/definitions/model.Response'
+        "404":
+          description: Model Not Found
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Create a new infra migration user model (on-premise or cloud)
+      tags:
+      - '[API] Migration User Models'
+  /infra-model/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a specific infra migration user model by ID. Works for both
+        on-premise and cloud models without requiring the caller to specify the model
+        type.
+      operationId: DeleteInfraModel
+      parameters:
+      - description: Model ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully deleted the infra migration user model
+          schema:
+            type: string
+        "400":
+          description: Invalid request parameter
+          schema:
+            $ref: '#/definitions/model.Response'
+        "404":
+          description: Model Not Found
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Delete a specific infra migration user model (on-premise or cloud)
+      tags:
+      - '[API] Migration User Models'
+    get:
+      consumes:
+      - application/json
+      description: Get a specific infra migration user model by ID. Use 'modelType'
+        to specify whether it is an on-premise or cloud model.
+      operationId: GetInfraModel
+      parameters:
+      - description: Model ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Type of infra model to retrieve
+        enum:
+        - onprem
+        - cloud
+        in: query
+        name: modelType
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully obtained the infra migration user model
+          schema:
+            type: object
+        "400":
+          description: Invalid request parameter
+          schema:
+            $ref: '#/definitions/model.Response'
+        "404":
+          description: Model Not Found
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Get a specific infra migration user model (on-premise or cloud)
+      tags:
+      - '[API] Migration User Models'
+    put:
+      consumes:
+      - application/json
+      description: Update a specific infra migration user model by ID. Use 'modelType'
+        to specify whether it is an on-premise or cloud model.
+      operationId: UpdateInfraModel
+      parameters:
+      - description: Model ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Type of infra model to update
+        enum:
+        - onprem
+        - cloud
+        in: query
+        name: modelType
+        required: true
+        type: string
+      - description: Infra model information to update
+        in: body
+        name: Model
+        required: true
+        schema:
+          $ref: '#/definitions/handler.CreateInfraModelReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully updated the infra migration user model
+          schema:
+            type: object
+        "400":
+          description: Invalid request parameter
+          schema:
+            $ref: '#/definitions/model.Response'
+        "404":
+          description: Model Not Found
+          schema:
+            $ref: '#/definitions/model.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.Response'
+      summary: Update a specific infra migration user model (on-premise or cloud)
+      tags:
+      - '[API] Migration User Models'
   /model/{isTargetModel}:
     get:
       consumes:

--- a/pkg/api/rest/handler/cloud-user-model.go
+++ b/pkg/api/rest/handler/cloud-user-model.go
@@ -248,9 +248,668 @@ type OnPremModelRespInfo struct {
 	OnpremInfraModel onpremisemodel.OnpremInfra `json:"onpremiseInfraModel" validate:"required"`
 }
 
-// Caution!!)
-// Init Swagger : ]# swag init --parseDependency --parseInternal
-// Need to add '--parseDependency --parseInternal' in order to apply imported structures
+// ##############################################################################################
+// ### Unified Infra Migration User Model (On-Premise + Cloud)
+// ##############################################################################################
+
+// GetInfraModels godoc
+// @ID GetInfraModels
+// @Summary Get a list of infra migration user models (on-premise or cloud)
+// @Description Get a list of infra migration user models filtered by model type and source/target classification.
+// @Tags [API] Migration User Models
+// @Accept  json
+// @Produce  json
+// @Param modelType  query string true  "Type of infra model to retrieve" Enums(onprem, cloud)
+// @Param isTargetModel query string true "Whether to retrieve target models (true) or source models (false)" Enums(true, false)
+// @Success 200 {array}  map[string]interface{} "Successfully obtained infra migration user models"
+// @Failure 400 {object} model.Response "Invalid request parameter"
+// @Failure 404 {object} model.Response "Model Not Found"
+// @Failure 500 {object} model.Response
+// @Router /infra-model [get]
+func GetInfraModels(c echo.Context) error {
+	modelTypeParam := c.QueryParam("modelType")
+	if !strings.EqualFold(modelTypeParam, "onprem") && !strings.EqualFold(modelTypeParam, "cloud") {
+		newErr := fmt.Errorf("invalid request: 'modelType' must be 'onprem' or 'cloud', got '%s'", modelTypeParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isTargetModelParam := c.QueryParam("isTargetModel")
+	if !strings.EqualFold(isTargetModelParam, "true") && !strings.EqualFold(isTargetModelParam, "false") {
+		newErr := fmt.Errorf("invalid request: 'isTargetModel' must be 'true' or 'false', got '%s'", isTargetModelParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isTargetModel, err := strconv.ParseBool(isTargetModelParam)
+	if err != nil {
+		newErr := fmt.Errorf("invalid request: failed to parse 'isTargetModel': [%v]", err)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isCloudModelFilter := strings.EqualFold(modelTypeParam, "cloud")
+
+	log.Info().Msgf("# GetInfraModels: modelType=[%s], isTargetModel=[%v]", modelTypeParam, isTargetModel)
+
+	modelList, exists := lkvstore.GetWithPrefix("")
+	if !exists {
+		return c.JSON(http.StatusOK, []map[string]interface{}{})
+	}
+
+	var result []map[string]interface{}
+	for _, item := range modelList {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Skip software models
+		if isSoftwareModel, exists := m["isSoftwareModel"]; exists && isSoftwareModel == true {
+			continue
+		}
+
+		// Filter by isCloudModel
+		isCloudModelVal, cloudModelExists := m["isCloudModel"]
+		if !cloudModelExists {
+			continue
+		}
+		isCloudModelBool, ok := isCloudModelVal.(bool)
+		if !ok {
+			continue
+		}
+		if isCloudModelBool != isCloudModelFilter {
+			continue
+		}
+
+		// Filter by isTargetModel
+		isTargetModelVal, targetModelExists := m["isTargetModel"]
+		if !targetModelExists {
+			continue
+		}
+		isTargetModelBool, ok := isTargetModelVal.(bool)
+		if !ok {
+			continue
+		}
+		if isTargetModelBool != isTargetModel {
+			continue
+		}
+
+		result = append(result, m)
+	}
+
+	if len(result) == 0 {
+		return c.JSON(http.StatusOK, []map[string]interface{}{})
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// [Note]
+// CreateInfraModelReq is a unified request body for creating either an on-premise
+// or a cloud infra migration user model. Only the field matching the selected
+// 'modelType' needs to be provided (onpremiseInfraModel or cloudInfraModel).
+type CreateInfraModelReq struct {
+	UserId           string                      `json:"userId"`
+	IsInitUserModel  bool                        `json:"isInitUserModel"`
+	UserModelName    string                      `json:"userModelName"`
+	UserModelVer     string                      `json:"userModelVersion"`
+	Description      string                      `json:"description"`
+	CSP              string                      `json:"csp,omitempty"`
+	Region           string                      `json:"region,omitempty"`
+	Zone             string                      `json:"zone,omitempty"`
+	OnpremInfraModel onpremisemodel.OnpremInfra  `json:"onpremiseInfraModel,omitempty"`
+	CloudInfraModel  cloudmodel.RecommendedInfra `json:"cloudInfraModel,omitempty"`
+}
+
+// CreateInfraModel godoc
+// @ID CreateInfraModel
+// @Summary Create a new infra migration user model (on-premise or cloud)
+// @Description Create a new infra migration user model. Use 'modelType' to select on-premise or cloud, and 'isTargetModel' to select source or target model.
+// @Tags [API] Migration User Models
+// @Accept  json
+// @Produce  json
+// @Param modelType  query string true  "Type of infra model to create" Enums(onprem, cloud)
+// @Param isTargetModel query string true "Whether to create a target model (true) or a source model (false)" Enums(true, false)
+// @Param Model body CreateInfraModelReq true "Infra model information"
+// @Success 201 {object} object "Successfully created the infra migration user model"
+// @Failure 400 {object} model.Response "Invalid request parameter"
+// @Failure 404 {object} model.Response "Model Not Found"
+// @Failure 500 {object} model.Response
+// @Router /infra-model [post]
+func CreateInfraModel(c echo.Context) error {
+	modelTypeParam := c.QueryParam("modelType")
+	if !strings.EqualFold(modelTypeParam, "onprem") && !strings.EqualFold(modelTypeParam, "cloud") {
+		newErr := fmt.Errorf("invalid request: 'modelType' must be 'onprem' or 'cloud', got '%s'", modelTypeParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isTargetModelParam := c.QueryParam("isTargetModel")
+	if !strings.EqualFold(isTargetModelParam, "true") && !strings.EqualFold(isTargetModelParam, "false") {
+		newErr := fmt.Errorf("invalid request: 'isTargetModel' must be 'true' or 'false', got '%s'", isTargetModelParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isTargetModel, err := strconv.ParseBool(isTargetModelParam)
+	if err != nil {
+		newErr := fmt.Errorf("invalid request: failed to parse 'isTargetModel': [%v]", err)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	reqBody := new(CreateInfraModelReq)
+	if err := c.Bind(reqBody); err != nil {
+		newErr := fmt.Errorf("invalid request : [%v]", err)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isCloudModel := strings.EqualFold(modelTypeParam, "cloud")
+	log.Info().Msgf("# CreateInfraModel: modelType=[%s], isTargetModel=[%v]", modelTypeParam, isTargetModel)
+
+	id := uuid.New().String()
+
+	createTime, err := getSeoulCurrentTime()
+	if err != nil {
+		msg := "Failed to Get the Current time!!"
+		log.Debug().Msg(msg)
+	}
+
+	var resultVer string
+	modelVer, err := getModuleVersion("github.com/cloud-barista/cm-beetle/imdl")
+	if err != nil {
+		msg := "Failed to Get the 'cm-beetle/imdl' module verion!!"
+		log.Debug().Msg(msg)
+	} else {
+		if len(modelVer) > 10 {
+			release, err := getLatestRelease("cloud-barista", "cm-beetle/imdl")
+			if err != nil {
+				msg := "Failed to Get the latest release."
+				log.Error().Msgf("%s : [%v]", msg, err)
+				newErr := fmt.Errorf("%s : [%v]", msg, err)
+				res := model.Response{
+					Success: false,
+					Text:    newErr.Error(),
+				}
+				return c.JSON(http.StatusInternalServerError, res)
+			}
+			log.Info().Msgf("Latest version: %s\n", release.TagName)
+			resultVer = release.TagName
+		} else {
+			resultVer = modelVer
+		}
+	}
+
+	if isCloudModel {
+		// --- Create a Cloud migration user model ---
+		userModel := CloudModelRespInfo{
+			Id:              id,
+			UserId:          reqBody.UserId,
+			IsTargetModel:   isTargetModel,
+			IsInitUserModel: reqBody.IsInitUserModel,
+			UserModelName:   reqBody.UserModelName,
+			Description:     reqBody.Description,
+			UserModelVer:    reqBody.UserModelVer,
+			CreateTime:      createTime,
+			CSP:             reqBody.CSP,
+			Region:          reqBody.Region,
+			Zone:            reqBody.Zone,
+			IsCloudModel:    true,
+			CloudModelVer:   resultVer,
+			ModelType:       CloudModel,
+			CloudInfraModel: reqBody.CloudInfraModel,
+		}
+		log.Info().Msgf("Cloud Model version: %s", resultVer)
+
+		lkvstore.Put(userModel.Id, userModel)
+
+		if err := lkvstore.SaveLkvStore(); err != nil {
+			msg := "Failed to Save the lkvstore to file."
+			log.Error().Msgf("%s : [%v]", msg, err)
+			newErr := fmt.Errorf("%s : [%v]", msg, err)
+			return c.JSON(http.StatusInternalServerError, newErr)
+		}
+		log.Info().Msg("Succeeded in Saving the lkvstore to file.")
+
+		return c.JSON(http.StatusCreated, userModel)
+	}
+
+	// --- Create an On-premise migration user model ---
+	userModel := OnPremModelRespInfo{
+		Id:               id,
+		UserId:           reqBody.UserId,
+		IsInitUserModel:  reqBody.IsInitUserModel,
+		UserModelName:    reqBody.UserModelName,
+		UserModelVer:     reqBody.UserModelVer,
+		Description:      reqBody.Description,
+		OnPremModelVer:   resultVer,
+		CreateTime:       createTime,
+		IsTargetModel:    isTargetModel,
+		IsCloudModel:     false,
+		ModelType:        OnPremModel,
+		OnpremInfraModel: reqBody.OnpremInfraModel,
+	}
+	log.Info().Msgf("On-premise Model version: %s", resultVer)
+
+	lkvstore.Put(userModel.Id, userModel)
+
+	if err := lkvstore.SaveLkvStore(); err != nil {
+		msg := "Failed to Save the lkvstore to file."
+		log.Error().Msgf("%s : [%v]", msg, err)
+		newErr := fmt.Errorf("%s : [%v]", msg, err)
+		return c.JSON(http.StatusInternalServerError, newErr)
+	}
+	log.Info().Msg("Succeeded in Saving the lkvstore to file.")
+
+	return c.JSON(http.StatusCreated, userModel)
+}
+
+// GetInfraModel godoc
+// @ID GetInfraModel
+// @Summary Get a specific infra migration user model (on-premise or cloud)
+// @Description Get a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model.
+// @Tags [API] Migration User Models
+// @Accept  json
+// @Produce  json
+// @Param id          path  string true "Model ID"
+// @Param modelType  query string true  "Type of infra model to retrieve" Enums(onprem, cloud)
+// @Success 200 {object} object "Successfully obtained the infra migration user model"
+// @Failure 400 {object} model.Response "Invalid request parameter"
+// @Failure 404 {object} model.Response "Model Not Found"
+// @Failure 500 {object} model.Response
+// @Router /infra-model/{id} [get]
+func GetInfraModel(c echo.Context) error {
+	if strings.EqualFold(c.Param("id"), "") {
+		newErr := fmt.Errorf("invalid request: model id is required")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	modelTypeParam := c.QueryParam("modelType")
+	if !strings.EqualFold(modelTypeParam, "onprem") && !strings.EqualFold(modelTypeParam, "cloud") {
+		newErr := fmt.Errorf("invalid request: 'modelType' must be 'onprem' or 'cloud', got '%s'", modelTypeParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isCloudModelFilter := strings.EqualFold(modelTypeParam, "cloud")
+	log.Info().Msgf("# GetInfraModel: id=[%s], modelType=[%s]", c.Param("id"), modelTypeParam)
+
+	userModel, exists := lkvstore.Get(c.Param("id"))
+	if !exists {
+		newErr := fmt.Errorf("failed to find the model from db with id: [%s]", c.Param("id"))
+		log.Error().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusNotFound, res)
+	}
+
+	m, ok := userModel.(map[string]interface{})
+	if !ok {
+		newErr := fmt.Errorf("internal error: unexpected model data format")
+		log.Error().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	// --- Verify modelType matches the stored model ---
+	isCloudModelVal, cloudModelExists := m["isCloudModel"]
+	if !cloudModelExists {
+		newErr := fmt.Errorf("'isCloudModel' does not exist. This is neither on-premise nor cloud user model")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+	isCloudModelBool, ok := isCloudModelVal.(bool)
+	if !ok {
+		newErr := fmt.Errorf("'isCloudModel' is not a boolean type")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+	if isCloudModelBool != isCloudModelFilter {
+		expected := "onprem"
+		if isCloudModelBool {
+			expected = "cloud"
+		}
+		newErr := fmt.Errorf("model type mismatch: the model with id [%s] is a '%s' model, not '%s'", c.Param("id"), expected, modelTypeParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	return c.JSON(http.StatusOK, m)
+}
+
+// UpdateInfraModel godoc
+// @ID UpdateInfraModel
+// @Summary Update a specific infra migration user model (on-premise or cloud)
+// @Description Update a specific infra migration user model by ID. Use 'modelType' to specify whether it is an on-premise or cloud model.
+// @Tags [API] Migration User Models
+// @Accept  json
+// @Produce  json
+// @Param id          path  string true "Model ID"
+// @Param modelType  query string true  "Type of infra model to update" Enums(onprem, cloud)
+// @Param Model body CreateInfraModelReq true "Infra model information to update"
+// @Success 200 {object} object "Successfully updated the infra migration user model"
+// @Failure 400 {object} model.Response "Invalid request parameter"
+// @Failure 404 {object} model.Response "Model Not Found"
+// @Failure 500 {object} model.Response
+// @Router /infra-model/{id} [put]
+func UpdateInfraModel(c echo.Context) error {
+	if strings.EqualFold(c.Param("id"), "") {
+		newErr := fmt.Errorf("invalid request: model id is required")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+	reqId := c.Param("id")
+
+	modelTypeParam := c.QueryParam("modelType")
+	if !strings.EqualFold(modelTypeParam, "onprem") && !strings.EqualFold(modelTypeParam, "cloud") {
+		newErr := fmt.Errorf("invalid request: 'modelType' must be 'onprem' or 'cloud', got '%s'", modelTypeParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	isCloudModelFilter := strings.EqualFold(modelTypeParam, "cloud")
+	log.Info().Msgf("# UpdateInfraModel: id=[%s], modelType=[%s]", reqId, modelTypeParam)
+
+	reqBody := new(CreateInfraModelReq)
+	if err := c.Bind(reqBody); err != nil {
+		newErr := fmt.Errorf("invalid request : [%v]", err)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	existingRaw, exists := lkvstore.Get(reqId)
+	if !exists {
+		newErr := fmt.Errorf("failed to find the model from db with id: [%s]", reqId)
+		log.Error().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusNotFound, res)
+	}
+
+	existing, ok := existingRaw.(map[string]interface{})
+	if !ok {
+		newErr := fmt.Errorf("internal error: unexpected model data format")
+		log.Error().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	// --- Verify modelType matches the stored model ---
+	isCloudModelVal, cloudModelExists := existing["isCloudModel"]
+	if !cloudModelExists {
+		newErr := fmt.Errorf("'isCloudModel' does not exist. This is neither on-premise nor cloud user model")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+	isCloudModelBool, ok := isCloudModelVal.(bool)
+	if !ok {
+		newErr := fmt.Errorf("'isCloudModel' is not a boolean type")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+	if isCloudModelBool != isCloudModelFilter {
+		expected := "onprem"
+		if isCloudModelBool {
+			expected = "cloud"
+		}
+		newErr := fmt.Errorf("model type mismatch: the model with id [%s] is a '%s' model, not '%s'", reqId, expected, modelTypeParam)
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	createTime, _ := existing["createTime"].(string)
+	isTargetModelBool, _ := existing["isTargetModel"].(bool)
+
+	updateTime, err := getSeoulCurrentTime()
+	if err != nil {
+		log.Debug().Msg("Failed to Get the Current time!!")
+	}
+
+	if isCloudModelFilter {
+		cloudModelVer, _ := existing["cloudModelVersion"].(string)
+
+		updatedModel := CloudModelRespInfo{
+			Id:              reqId,
+			UserId:          reqBody.UserId,
+			IsTargetModel:   isTargetModelBool,
+			IsInitUserModel: reqBody.IsInitUserModel,
+			UserModelName:   reqBody.UserModelName,
+			Description:     reqBody.Description,
+			UserModelVer:    reqBody.UserModelVer,
+			CreateTime:      createTime,
+			UpdateTime:      updateTime,
+			CSP:             reqBody.CSP,
+			Region:          reqBody.Region,
+			Zone:            reqBody.Zone,
+			IsCloudModel:    true,
+			CloudModelVer:   cloudModelVer,
+			ModelType:       CloudModel,
+			CloudInfraModel: reqBody.CloudInfraModel,
+		}
+		log.Info().Msgf("Cloud Model version (preserved): %s", cloudModelVer)
+
+		lkvstore.Put(reqId, updatedModel)
+		if err := lkvstore.SaveLkvStore(); err != nil {
+			msg := "Failed to Save the lkvstore to file."
+			log.Error().Msgf("%s : [%v]", msg, err)
+			newErr := fmt.Errorf("%s : [%v]", msg, err)
+			res := model.Response{
+				Success: false,
+				Text:    newErr.Error(),
+			}
+			return c.JSON(http.StatusInternalServerError, res)
+		}
+		log.Info().Msg("Succeeded in Saving the lkvstore to file.")
+
+		saved, _ := lkvstore.Get(reqId)
+		return c.JSON(http.StatusOK, saved)
+	}
+
+	onpremModelVer, _ := existing["onpremModelVersion"].(string)
+
+	updatedModel := OnPremModelRespInfo{
+		Id:               reqId,
+		UserId:           reqBody.UserId,
+		IsInitUserModel:  reqBody.IsInitUserModel,
+		UserModelName:    reqBody.UserModelName,
+		UserModelVer:     reqBody.UserModelVer,
+		Description:      reqBody.Description,
+		OnPremModelVer:   onpremModelVer,
+		CreateTime:       createTime,
+		UpdateTime:       updateTime,
+		IsTargetModel:    isTargetModelBool,
+		IsCloudModel:     false,
+		ModelType:        OnPremModel,
+		OnpremInfraModel: reqBody.OnpremInfraModel,
+	}
+	log.Info().Msgf("On-premise Model version (preserved): %s", onpremModelVer)
+
+	lkvstore.Put(reqId, updatedModel)
+	if err := lkvstore.SaveLkvStore(); err != nil {
+		msg := "Failed to Save the lkvstore to file."
+		log.Error().Msgf("%s : [%v]", msg, err)
+		newErr := fmt.Errorf("%s : [%v]", msg, err)
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+	log.Info().Msg("Succeeded in Saving the lkvstore to file.")
+
+	saved, _ := lkvstore.Get(reqId)
+	return c.JSON(http.StatusOK, saved)
+}
+
+// DeleteInfraModel godoc
+// @ID DeleteInfraModel
+// @Summary Delete a specific infra migration user model (on-premise or cloud)
+// @Description Delete a specific infra migration user model by ID. Works for both on-premise and cloud models without requiring the caller to specify the model type.
+// @Tags [API] Migration User Models
+// @Accept  json
+// @Produce  json
+// @Param id path string true "Model ID"
+// @Success 200 {string} string "Successfully deleted the infra migration user model"
+// @Failure 400 {object} model.Response "Invalid request parameter"
+// @Failure 404 {object} model.Response "Model Not Found"
+// @Failure 500 {object} model.Response
+// @Router /infra-model/{id} [delete]
+func DeleteInfraModel(c echo.Context) error {
+	if strings.EqualFold(c.Param("id"), "") {
+		newErr := fmt.Errorf("invalid request: model id is required")
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	log.Info().Msgf("# DeleteInfraModel: id=[%s]", c.Param("id"))
+
+	existingRaw, exists := lkvstore.Get(c.Param("id"))
+	if !exists {
+		newErr := fmt.Errorf("failed to find the model from db with id: [%s]", c.Param("id"))
+		log.Error().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusNotFound, res)
+	}
+
+	existing, ok := existingRaw.(map[string]interface{})
+	if !ok {
+		newErr := fmt.Errorf("internal error: unexpected model data format")
+		log.Error().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+
+	// --- Verify this is an infra model (not a software model) ---
+	if isSoftwareModel, exists := existing["isSoftwareModel"]; exists && isSoftwareModel == true {
+		newErr := fmt.Errorf("invalid request: the model with id [%s] is a software model, not an infra model", c.Param("id"))
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+	if _, cloudModelExists := existing["isCloudModel"]; !cloudModelExists {
+		newErr := fmt.Errorf("invalid request: the model with id [%s] is neither an on-premise nor a cloud infra model", c.Param("id"))
+		log.Warn().Msg(newErr.Error())
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusBadRequest, res)
+	}
+
+	lkvstore.Delete(c.Param("id"))
+	log.Info().Msgf("Succeeded in Deleting the model : [%s]", c.Param("id"))
+
+	if err := lkvstore.SaveLkvStore(); err != nil {
+		msg := "Failed to Save the lkvstore to file."
+		log.Error().Msgf("%s : [%v]", msg, err)
+		newErr := fmt.Errorf("%s : [%v]", msg, err)
+		res := model.Response{
+			Success: false,
+			Text:    newErr.Error(),
+		}
+		return c.JSON(http.StatusInternalServerError, res)
+	}
+	log.Info().Msg("Succeeded in Saving the lkvstore to file.")
+
+	return c.JSON(http.StatusOK, "Succeeded in Deleting the infra model")
+}
 
 type GetOnPremModelsResp struct {
 	Models []OnPremModelRespInfo `json:"models"`

--- a/pkg/api/rest/server.go
+++ b/pkg/api/rest/server.go
@@ -171,6 +171,12 @@ func RunServer(port string) {
 	gModel.GET("/model/:isTargetModel", handler.GetModels)
 	gModel.GET("/model/version", handler.GetModelsVersion)
 
+	gModel.GET("/infra-model", handler.GetInfraModels)
+	gModel.POST("/infra-model", handler.CreateInfraModel)
+	gModel.GET("/infra-model/:id", handler.GetInfraModel)
+	gModel.PUT("/infra-model/:id", handler.UpdateInfraModel)
+	gModel.DELETE("/infra-model/:id", handler.DeleteInfraModel)
+
 	gModel.POST("/onpremmodel", handler.CreateOnPremModel)
 	gModel.GET("/onpremmodel", handler.GetOnPremModels)
 	gModel.GET("/onpremmodel/:id", handler.GetOnPremModel)


### PR DESCRIPTION
- Add feature to Manage Infra Migration User Models (On-Premise + Cloud) through Unified API
  - Update cloud-user-model.go
- Update API routes to Add new APIs
  - Update server.go
- Update Swagger API docs

[ API call examples ]
```
# Get All On-premise Source User Models
GET /damselfly/infra-model?modelType=onprem&isTargetModel=false

# Get All Cloud Target User Models
GET /damselfly/infra-model?modelType=cloud&isTargetModel=true

# Create an On-premise Source User Model
POST /damselfly/infra-model?modelType=onprem&isTargetModel=false
  Body: { "userModelName": "...", "onpremiseInfraModel": { ... } }

# Create a Cloud Target User Model
POST /damselfly/infra-model?modelType=cloud&isTargetModel=true
  Body: { "userModelName": "...", "csp": "aws", "cloudInfraModel": { ... } }

# Get a Specific On-premise User Model
GET /damselfly/infra-model/{id}?modelType=onprem

# Get a Specific Cloud User Model
GET /damselfly/infra-model/{id}?modelType=cloud

# Update an On-premise User Model
PUT /damselfly/infra-model/{id}?modelType=onprem
  Body: { "userModelName": "...", "onpremiseInfraModel": { ... } }

# Update a Cloud User Model
PUT /damselfly/infra-model/{id}?modelType=cloud
  Body: { "userModelName": "...", "csp": "aws", "cloudInfraModel": { ... } }

# Delete a Specific Infra User Model
DELETE /damselfly/infra-model/{id}
```
- Related issue : https://github.com/cloud-barista/cm-damselfly/issues/42
